### PR TITLE
Disable SPA when modifier key is pressed

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -520,6 +520,11 @@
    */
   senna.App.prototype.onDocClick_ = function(event) {
     var link = event.target;
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+      console.log('Stop the SPA navigation when a modifier key is pressed');
+      return;
+    }
+
     while (link && link.tagName !== 'A') {
       link = link.parentNode;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -404,6 +404,29 @@ describe('Senna', function() {
     });
   });
 
+  it('should not navigate to links clicked with modifier keys', function(done) {
+    var link = document.querySelector('a[href="/base/page#hash"]');
+
+    function simulateEvent(element, type, modifiers) {
+      modifiers.cancelable = true;
+      element.dispatchEvent(new MouseEvent(type, modifiers));
+    }
+
+    simulateEvent(link, 'click', {altKey: true});
+    assert.strictEqual(app.pendingNavigate, null);
+
+    simulateEvent(link, 'click', {ctrlKey: true});
+    assert.strictEqual(app.pendingNavigate, null);
+
+    simulateEvent(link, 'click', {metaKey: true});
+    assert.strictEqual(app.pendingNavigate, null);
+
+    simulateEvent(link, 'click', {shiftKey: true});
+    assert.strictEqual(app.pendingNavigate, null);
+
+    done();
+  });
+
   it('should navigate to previous page asynchronously', function(done) {
     app.navigate('/base/delayed200ms').then(function() {
       var start = Date.now();


### PR DESCRIPTION
When I try to navigate to a SPA-enabled link, but press a modifier key (option, cmd, shift on OS X) Senna must not try to load the content, but return early not canceling the browser's default event handling otherwise it'll make it impossible for the user to open link in another window, tab, or download it by using modifier keys.

Problem verified in Chrome, Firefox, and Safari. I've not tested on other browsers and only tested with an Apple keyboard. Need to verify if this issue also happens when pressing the ctrl (control) key on on-Apple keyboards / computers.
