### PR TITLE
Replace the surface content with the new one

### DIFF
--- a/src/senna.js
+++ b/src/senna.js
@@ -17,15 +17,6 @@
   };
 
   /**
-   * Replace the parent element by the child.
-   * @param {!Node} parent The node element to be replaced.
-   * @param {!Node|String} child The thing to replace the parent.
-   */
-  senna.replace = function(parent, child){
-    return parent.innerHTML = senna.parseScripts(child).innerHTML;
-  }
-
-  /**
    * Creates a new function that, when called, has its this keyword set to the
    * provided value, with a given sequence of arguments preceding any provided
    * when the new function is called.

--- a/src/surface/Surface.js
+++ b/src/surface/Surface.js
@@ -12,6 +12,23 @@
       throw new Error('Surface element id not specified.');
     }
     this.setId(id);
+
+    // if the new surface does not contain a child with id "mysurface-default"
+    // it will create
+    if(!document.getElementById(this.makeId_(senna.Surface.DEFAULT)) && this.getEl()){
+      var parent = this.getEl();
+      var children = [];
+      while (parent.firstChild) {
+        var removedEl = parent.removeChild(parent.firstChild);
+        children.push(removedEl);
+      }
+      var child = this.createChild(senna.Surface.DEFAULT);
+      for (var i = 0; i < children.length; i++) {
+        child.appendChild(children[i]);
+      }
+      parent.appendChild(child);
+      this.activeChild = child;
+    }
   };
 
   /**
@@ -135,7 +152,7 @@
     this.transition(child, null);
 
     if (el) {
-      senna.replace(el, child);
+      senna.append(el, child);
     }
 
     return child;


### PR DESCRIPTION
I have tested in some portals and when i clicked at a link, the new content was added below of Surface (not replaced it).

Now, works fine.

Scenario:
1. Go to a portal with no senna.js (http://portalpadrao.plone.org.br/)
2. Load senna.js from DevTools console.
3. run the script:

``` javascript
var app = new senna.App();
app.setBasePath('/');
app.addSurfaces('portal-column-content');
app.addRoutes([
  new senna.Route('assuntos/editoria-a', senna.HtmlScreen),
  new senna.Route('servicos/perguntas-frequentes', senna.HtmlScreen)
]);
```

Click at "Perguntas Frequentes", for example. The new page content will be loaded at bottom of page.
