### PR TITLE
An error should be issued if a surface element does not have an id

### DIFF
--- a/src/utils/DataAttributeHandler.js
+++ b/src/utils/DataAttributeHandler.js
@@ -121,6 +121,10 @@
 
       var surfaceId = surfaces[i].id;
 
+      if (!surfaceId) {
+        console.error('An id attribute is required for all "data-senna-surface" elements');
+      }
+
       if (surfaceId && !this.app.surfaces[surfaceId]) {
         this.app.addSurfaces(surfaceId);
         console.log('Senna scanned surface ' + surfaceId);


### PR DESCRIPTION
It is a good practice to use classes to identify every element in the
page, even though it is supposed to exist only once.
Since senna requires an id for a surface instead of a class, it should
issue an error when a developer starts using senna without specifying
and id attribute.
