### PR TITLE
Firefox on Windows triggers the click event for the right mouse button

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -523,6 +523,11 @@
       return;
     }
 
+    if (event.button) {
+      console.log('Navigate aborted, invalid mouse key is pressed');
+      return;
+    }
+
     var link = event.target;
     while (link && link.tagName !== 'A') {
       link = link.parentNode;


### PR DESCRIPTION
Unfortunately I am having trouble to execute `gulp test` in windows. Several tests fail. I suppose this is going to be properly addressed once #52 is landed.

For that reason I wasn't able to create a proper test case for this pull, but the test should be pretty straightforward:

``` javascript
var element = document.querySelector('a[href="/base/page#hash"]');
// https://developer.mozilla.org/en-US/docs/Web/API/event.button
element.dispatchEvent(new MouseEvent('click', {button: 2}));
assert.strictEqual(app.pendingNavigate, null);
done();
```
