### PR TITLE
Should check if attribute exists in order to throw Error

### DIFF
--- a/src/utils/DataAttributeHandler.js
+++ b/src/utils/DataAttributeHandler.js
@@ -116,13 +116,14 @@
    * Scans surfaces with data attribute.
    */
   senna.DataAttributeHandler.prototype.scanSurfaces = function() {
+    var surface, surfaceId;
     var surfaces = this.baseElement.querySelectorAll('[data-senna-surface]');
     for (var i = 0; i < surfaces.length; i++) {
+      surface = surfaces[i];
+      surfaceId = surface.id;
 
-      var surfaceId = surfaces[i].id;
-
-      if (!senna.isDef(surfaceId)) {
-        throw new Error('Id attribute is required for surfaces');
+      if (!surface.hasAttribute('id')) {
+        throw new Error('Surface element id not specified.');
       }
 
       if (surfaceId && !this.app.surfaces[surfaceId]) {


### PR DESCRIPTION
When a DOM element does not have an id it returns an empty string instead of undefined.

Related to https://github.com/eduardolundgren/senna/commit/534004fc37ed5981fe3ffd89fdd9b3aac91cd603#commitcomment-7767287
