### PR TITLE
Add .project to .gitignore to play nice with Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components
 coverage
 docs
 node_modules
+.project


### PR DESCRIPTION
I use Eclipse to develop both Java and Javascript, it has a wonderful tool called Egit which abstracts common git commands in a pretty intuitive interface.

The problem is that Eclipse requires a mandatory `.project` file in the project root for any project imported into the workspace. Since this project already uses a `.gitignore` I can't just create one ignoring itself and Eclipse's `.project`.

I understand custom editor files should be dealt in a per environment basis whenever possible, but in this case I can't figure out a way to handle this, other than just ignoring the file when commiting (visually annoying) or suggesting the change to be made in the main repo.
