### PR TITLE
Adding purgeCache method.

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -696,6 +696,14 @@
     delete this.screens[path];
   };
 
+  senna.App.prototype.purgeCache = function() {
+    for (var i in this.screens) {
+      if (i !== this.activePath) {
+        this.removeScreen_(i, this.screens[i]);
+      }
+    }
+  };
+
   /**
    * Sets link base path.
    * @param {!String} path

--- a/test/test.js
+++ b/test/test.js
@@ -582,4 +582,28 @@ describe('Senna', function() {
     });
   });
 
+  it('should not invalidate active screen', function(done) {
+    app.navigate('/base/page#hash').then(function() {
+      app.purgeCache();
+
+      assert.ok(app.screens[app.activePath] instanceof senna.Screen);
+
+      done();
+    });
+  });
+
+  it('should invalidate all screens when no screen is active', function(done) {
+    app.screens = {
+      '/cached': new senna.Screen()
+    };
+
+    assert.ok(this.activeScreen === undefined);
+
+    app.purgeCache();
+
+    assert.ok(Object.getOwnPropertyNames(app.screens).length === 0);
+
+    done();
+  });
+
 });


### PR DESCRIPTION
This tries to solve https://github.com/eduardolundgren/senna/issues/68

I haven't researched about the ETag yet, so I'm leaving the other issue open until I do it.

I suppose we only need to avoid caching the [pure] HTMLScreen, if the server is sending ETag but I still have to confirm it. If correct, I'm going to add this info on the docs.