### PR TITLE
Removes the child surface after the transition end

### DIFF
--- a/src/surface/Surface.js
+++ b/src/surface/Surface.js
@@ -244,10 +244,6 @@
       to = this.defaultChild;
     }
 
-    if (from && from !== to) {
-      senna.remove(from);
-    }
-
     // Avoid repainting if the child is already in place or the element does
     // not exist
     var el = this.getEl();
@@ -256,6 +252,13 @@
     }
 
     var deferred = this.transition(from, to);
+    
+    deferred.then( function() {
+      if(from && from !== to) {
+        senna.remove(from);
+      }
+    });
+
     this.activeChild = to;
 
     return deferred;


### PR DESCRIPTION
In the method of Surface, the 'from' element is removed before the transition is called. Therefore the transition to the 'from' element are never "executed".
