### PR TITLE
Mutate styles hrefs to be unique for IE to prevent caching issues

### DIFF
--- a/src/screen/HtmlScreen.js
+++ b/src/screen/HtmlScreen.js
@@ -6,6 +6,8 @@ import CancellablePromise from 'metal-promise';
 import globals from '../globals/globals';
 import RequestScreen from './RequestScreen';
 import Surface from '../surface/Surface';
+import UA from 'metal-useragent';
+import Uri from 'metal-uri';
 
 class HtmlScreen extends RequestScreen {
 
@@ -59,6 +61,9 @@ class HtmlScreen extends RequestScreen {
 		var isTemporaryStyle = dom.match(newStyle, HtmlScreen.selectors.stylesTemporary);
 		if (isTemporaryStyle) {
 			this.pendingStyles.push(newStyle);
+			if (UA.isIe && newStyle.href) {
+				newStyle.href = new Uri(newStyle.href).makeUnique().toString();
+			}
 		}
 		if (newStyle.id) {
 			var styleInDoc = globals.document.getElementById(newStyle.id);

--- a/test/screen/HtmlScreen.js
+++ b/test/screen/HtmlScreen.js
@@ -4,6 +4,7 @@ import dom from 'metal-dom';
 import globals from '../../src/globals/globals';
 import HtmlScreen from '../../src/screen/HtmlScreen';
 import Surface from '../../src/surface/Surface';
+import UA from 'metal-useragent';
 
 describe('HtmlScreen', function() {
 
@@ -252,6 +253,18 @@ describe('HtmlScreen', function() {
 				done();
 			});
 		assert.ok(screen.pendingStyles);
+		screen.activate();
+	});
+
+	it('should mutate temporary style hrefs to be unique on ie browsers', (done) => {
+		UA.testUserAgent('MSIE'); // Simulates ie user agent
+		var screen = new HtmlScreen();
+		screen.allocateVirtualDocumentForContent('<link id="testIEStlye" data-senna-track="temporary" rel="stylesheet" href="testIEStlyes.css">');
+		screen.evaluateStyles({})
+			.then(() => {
+				assert.ok(!document.getElementById('testIEStlye').href.endsWith('testIEStlyes.css'));
+				done();
+			});
 		screen.activate();
 	});
 


### PR DESCRIPTION
This change makes style hrefs unique in internet explorer.  I think the main drawback is that cacheing style sheets in IE will no longer work.  

I also included a test to cover this use case.

This is related to https://issues.liferay.com/browse/LPS-64816 and https://github.com/liferay/senna.js/issues/124.