### PR TITLE
Fixes bug with having "/" route with base path - Fixes #127

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ metal.registerTasks({
 	globalName: 'senna',
 	mainBuildJsTasks: ['build:globals'],
 	moduleName: 'senna',
+	noSoy: true,
 	testBrowsers: ['Chrome', 'Firefox', 'Safari', 'IE10 - Win7', 'IE11 - Win7'],
 	testSaucelabsBrowsers: {
 		sl_chrome: {

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -417,7 +417,11 @@ class App extends EventEmitter {
 			return null;
 		}
 
-		path = utils.getUrlPathWithoutHash(path).substr(this.basePath.length);
+		path = utils.getUrlPathWithoutHash(path);
+
+		// Makes sure that the path substring will be in the expected format
+		// (that is, will end with a "/").
+		path = utils.getUrlPathWithoutHash(path.substr(this.basePath.length));
 
 		for (var i = 0; i < this.routes.length; i++) {
 			var route = this.routes[i];

--- a/test/app/App.js
+++ b/test/app/App.js
@@ -327,7 +327,9 @@ describe('App', function() {
 			}
 		};
 		this.app.setBasePath('/base');
-		this.app.addRoutes(new Route('/path', Screen));
+		this.app.addRoutes([new Route('/', Screen), new Route('/path', Screen)]);
+		assert.ok(this.app.canNavigate('http://localhost/base/'));
+		assert.ok(this.app.canNavigate('http://localhost/base'));
 		assert.ok(this.app.canNavigate('http://localhost/base/path'));
 		assert.ok(!this.app.canNavigate('http://localhost/base/path1'));
 		assert.ok(!this.app.canNavigate('http://localhost/path'));


### PR DESCRIPTION
Not sure if this is the best solution, but it works well, since the extra call to `utils.getUrlPathWithoutHash` guarantees that the path will be in the expected format.

This also contains a commit that sets a gulp-metal option to avoid warnings related to senna.js not using soy.