### PR TITLE
Precompiles code to commonjs when published

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components
 coverage
 docs
 node_modules
+/lib

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "node": ">=0.12.0",
     "npm": ">=3.0.0"
   },
-  "main": "src/app/App.js",
+  "jsnext:main": "src/app/App.js",
+  "main": "lib/app/App.js",
   "files": [
     "build",
+    "lib",
     "src/**/*.js",
     "test/**/*.js"
   ],
@@ -19,6 +21,10 @@
     "email": "edu@rdo.io",
     "web": "http://eduardo.io",
     "twitter": "eduardolundgren"
+  },
+  "scripts": {
+    "compile": "babel --presets es2015 -d lib/ src/",
+    "prepublish": "npm run compile"
   },
   "keywords": [
     "spa",
@@ -39,6 +45,8 @@
     "metal-useragent": "^1.0.0-rc.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.4.5",
+    "babel-preset-es2015": "^6.3.13",
     "gulp": "^3.8.11",
     "gulp-connect": "^2.3.1",
     "gulp-header": "^1.7.1",


### PR DESCRIPTION
Right now users are forced to always compile senna.js code themselves when using it through es6 imports. It's common practice to provide the precompiled code in commonjs in the "lib" folder, so that developers using build tools like "browserify" and "webpack" can worry just on compiling their own code, instead of having to do it for dependencies as well.

See https://github.com/metal/metal.js/issues/109 for more details.