### PR TITLE
Uses default listeners from Metal.js

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -584,11 +584,6 @@ class App extends EventEmitter {
 			return;
 		}
 
-		if (this.allowPreventNavigate && event.defaultPrevented) {
-			console.log('Navigate prevented');
-			return;
-		}
-
 		globals.capturedFormElement = event.capturedFormElement;
 
 		var navigateFailed = false;
@@ -960,7 +955,7 @@ class App extends EventEmitter {
 		if (this.formEventHandler_) {
 			this.formEventHandler_.removeListener();
 		}
-		this.formEventHandler_ = dom.delegate(document, 'submit', this.formSelector, this.onDocSubmitDelegate_.bind(this));
+		this.formEventHandler_ = dom.delegate(document, 'submit', this.formSelector, this.onDocSubmitDelegate_.bind(this), this.allowPreventNavigate);
 	}
 
 	/**
@@ -972,7 +967,7 @@ class App extends EventEmitter {
 		if (this.linkEventHandler_) {
 			this.linkEventHandler_.removeListener();
 		}
-		this.linkEventHandler_ = dom.delegate(document, 'click', this.linkSelector, this.onDocClickDelegate_.bind(this));
+		this.linkEventHandler_ = dom.delegate(document, 'click', this.linkSelector, this.onDocClickDelegate_.bind(this), this.allowPreventNavigate);
 	}
 
 	/**

--- a/test/app/App.js
+++ b/test/app/App.js
@@ -1034,7 +1034,7 @@ describe('App', function() {
 			exitDocumentFormElement();
 			done();
 		});
-		dom.on(form, 'submit', preventDefault);
+		dom.on(form, 'submit', sinon.stub());
 		dom.triggerEvent(form, 'submit');
 		assert.ok(globals.capturedFormElement);
 	});


### PR DESCRIPTION
That allows Metal.js to handle having senna.js's listener be called last, and only if not prevented. This makes senna.js work better in Metal.js environments.

@brunobasto could you take a look at this to confirm if it's all right? There was only one test failing after this, that was calling `preventDefault` on the **submit** event, but still expecting `globals.capturedFormElement` to be set. That used to work before because the form was being stored [before checking if the event was prevented](https://github.com/liferay/senna.js/blob/699953bcf78d6462975646e74e67dccef431e48f/src/app/App.js#L714). There's another line of code that does exactly that, but that only runs [after the prevented check](https://github.com/liferay/senna.js/blob/699953bcf78d6462975646e74e67dccef431e48f/src/app/App.js#L592) though, which actually makes sense since that object is only ever used inside senna.js during navigation. I changed the test to stop calling `preventDefault`, which I believe it was only calling to avoid creating another empty function. Let me know if you think this can cause any problems though, with people accessing this variable from the outside even when the event is prevented for example. In that case we could have two listeners, one just for capturing this object, and the other for doing the navigation, so that the last one can be used as a default listener.