### PR TITLE
Uses babel-preset-metal instead of babel-preset-es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test/**/*.js"
   ],
   "scripts": {
-    "compile": "babel --presets es2015 -d lib/ src/",
+    "compile": "babel --presets metal -d lib/ src/",
     "prepublish": "npm run compile"
   },
   "keywords": [
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-metal": "^4.0.0",
     "gulp": "^3.8.11",
     "gulp-connect": "^4.0.0",
     "gulp-header": "^1.7.1",


### PR DESCRIPTION
babel-preset-metal compiles es2015 but also makes sure that the compiled code can run on IE 10 (by using loose mode, check it out at https://github.com/metal/babel-preset-metal/blob/master/index.js).