### PR TITLE
Update for #148

### DIFF
--- a/test/screen/HtmlScreen.js
+++ b/test/screen/HtmlScreen.js
@@ -268,13 +268,41 @@ describe('HtmlScreen', function() {
 	it('should mutate temporary style hrefs to be unique on ie browsers', (done) => {
 		UA.testUserAgent('MSIE'); // Simulates ie user agent
 		var screen = new HtmlScreen();
-		screen.allocateVirtualDocumentForContent('<link id="testIEStlye" data-senna-track="temporary" rel="stylesheet" href="testIEStlyes.css">');
-		screen.evaluateStyles({})
-			.then(() => {
-				assert.ok(document.getElementById('testIEStlye').href.indexOf('?zx=') > -1);
-				done();
+
+		screen.load('/url').then(() => {
+			screen.evaluateStyles({})
+				.then(() => {
+					assert.ok(document.getElementById('testIEStlye').href.indexOf('?zx=') > -1);
+					done();
+				});
+			screen.activate();
+		});
+
+		this.requests[0].respond(200, null, '<link id="testIEStlye" data-senna-track="temporary" rel="stylesheet" href="testIEStlye.css">');
+	});
+
+	it('link elements should only be loaded once in IE', (done) => {
+		UA.testUserAgent('MSIE'); // Simulates ie user agent
+		var screen = new HtmlScreen();
+		window.sentinelLoadCount = 0;
+
+		screen.load('/url').then(() => {
+			var style = screen.virtualQuerySelectorAll_('#bootstrapCDN')[0];
+			style.addEventListener('load', function() {
+				window.sentinelLoadCount++;
 			});
-		screen.activate();
+			screen.evaluateStyles({})
+				.then(() => {
+					setTimeout(function() {
+						assert.strictEqual(1, window.sentinelLoadCount);
+						delete window.sentinelLoadCount;
+						done();
+					}, 1000);
+				});
+			screen.activate();
+		});
+
+		this.requests[0].respond(200, null, '<link id="bootstrapCDN" data-senna-track="temporary" rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">');
 	});
 
 });


### PR DESCRIPTION
Hey Eduardo,

Attached is an update for https://github.com/liferay/senna.js/issues/148.

I created a test for the multiple load events in IE11.  (btw, microsoft confirmed the bug: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7940171/).

For the test, I had to use an external stylesheet.  I tried to use one I created in `/test`, but because of the way gulp-metal works I couldn't find a way for it to be served up when running gulp test.  As far as I can tell this is not configurable and would require changes in what we pass to karma in gulp-metal.

So I used the bootstrap CDN, which I really didn't want to do but couldn't find a way around it.

Now as for improving the [test](https://github.com/liferay/senna.js/blob/master/test/screen/HtmlScreen.js#L255) for the original [bug](https://github.com/liferay/senna.js/issues/124), I ran into other issues.  It seems that bug extends so far as using `getComputedStyle`, like you mentioned, will actually return the correct style, even though it is not displayed as such in the browser.

This got really complicated so please grab me if it doesn't make sense :sweat_smile:.

Thanks!

