### PR TITLE
Allows external events access to http error codes

### DIFF
--- a/src/screen/RequestScreen.js
+++ b/src/screen/RequestScreen.js
@@ -76,6 +76,7 @@ class RequestScreen extends Screen {
 		if (!this.isValidResponseStatusCode(status)) {
 			var error = new Error(errors.INVALID_STATUS);
 			error.invalidStatus = true;
+			error.statusCode = status;
 			throw error;
 		}
 	}

--- a/test/screen/RequestScreen.js
+++ b/test/screen/RequestScreen.js
@@ -178,6 +178,27 @@ describe('RequestScreen', function() {
 		this.requests[0].respond(404);
 	});
 
+	it('should return the correct http status code for "page not found"', (done) => {
+		new RequestScreen()
+			.load('/url')
+			.catch((error) => {
+				assert.strictEqual(error.statusCode, 404);
+				done();
+			});
+		this.requests[0].respond(404);
+	});
+
+	it('should return the correct http status code for "unauthorised"', (done) => {
+		new RequestScreen()
+			.load('/url')
+			.catch((error) => {
+				assert.strictEqual(error.statusCode, 401);
+				done();
+			});
+		this.requests[0].respond(401);
+	});
+
+
 	it('should fail for request errors response', (done) => {
 		new RequestScreen()
 			.load('/url')


### PR DESCRIPTION
E.G.
```javascript
app.on("endNavigate", function (e) {
	if (e.error) {
		if (e.error.invalidStatus) {
			switch (e.error.statusCode) {
				case 401: //Needs authorisation - Redirect to login page?
					console.log("AUTH REQUIRED")
					break;
				case 404: //Page not found
					console.log("NOT FOUND")
					break;
				case 500: //Error on page
					console.log("SERVER ERROR")
					break;
			}
		}
	}
});
```