### PR TITLE
Feature/issue/212

### DIFF
--- a/examples/email/dudu.html
+++ b/examples/email/dudu.html
@@ -16,6 +16,11 @@
 
   <!-- Including Senna -->
   <script src="../../build/globals/senna-debug.js"></script>
+  <script>
+    window.onbeforeunload = function() {
+      return 'test';
+    }
+  </script>
 </head>
 <!-- Initializing Senna via data attributes -->
 <body data-senna>

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1172,7 +1172,7 @@ class App extends EventEmitter {
 
 			window.onbeforeunload = e => {
 				this.emit('beforeUnload', e);
-				if (e.defaultPrevented) {
+				if (e && e.defaultPrevented) {
 					return true;
 				}
 			};

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1189,7 +1189,7 @@ class App extends EventEmitter {
 	 */
 	onBeforeUnloadDefault_(e) {
 		var func = window._onbeforeunload;
-		if (!func._overloaded && func()) {
+		if (func && !func._overloaded && func()) {
 			e.preventDefault();
 		}		
 	}

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -220,9 +220,11 @@ class App extends EventEmitter {
 		this.on('startNavigate', this.onStartNavigate_);
 		this.on('beforeNavigate', this.onBeforeNavigate_);
 		this.on('beforeNavigate', this.onBeforeNavigateDefault_, true);
+		this.on('beforeUnload', this.onBeforeUnloadDefault_);
 
 		this.setLinkSelector(this.linkSelector);
 		this.setFormSelector(this.formSelector);
+		this.updateGlobalEvents_();
 	}
 
 	/**
@@ -416,6 +418,7 @@ class App extends EventEmitter {
 			.then(() => this.maybeUpdateScrollPositionState_())
 			.then(() => this.syncScrollPositionSyncThenAsync_())
 			.then(() => this.finalizeNavigate_(path, nextScreen))
+			.then(() => this.updateGlobalEvents_())
 			.catch((reason) => {
 				this.isNavigationPending = false;
 				this.handleNavigateError_(path, nextScreen, reason);
@@ -778,6 +781,8 @@ class App extends EventEmitter {
 				return;
 			}
 		}
+
+		this.emit('beforeUnload', event);
 
 		this.emit('startNavigate', {
 			form: event.form,
@@ -1150,6 +1155,43 @@ class App extends EventEmitter {
 		};
 
 		return new CancellablePromise((resolve) => sync() & async.nextTick(() => sync() & resolve()));
+	}
+
+	/**
+	 * Checks whether the onbeforeunload global event handler is overloaded
+	 * by client code. If so, it replaces with a function that halts the normal
+	 * event flow in relation with the client onbeforeunload function.
+	 * This can be in most part used to prematurely terminate navigation to other pages
+	 * according to the given constrait(s). 
+	 * @protected 
+	 */
+	updateGlobalEvents_() {
+		if ('function' === typeof window.onbeforeunload) {
+
+			window._onbeforeunload = window.onbeforeunload;
+
+			window.onbeforeunload = e => {
+				this.emit('beforeUnload', e);
+				if (e.defaultPrevented) {
+					return true;
+				}
+			};
+
+			// mark the updated handler due unwanted recursion 
+			window.onbeforeunload._overloaded = true; 
+		}
+	}
+
+	/**
+	 * Custom event handler that executes the original listener that has been
+	 * added by the client code and terminates the navigation accordingly.
+	 * @protected
+	 */
+	onBeforeUnloadDefault_(e) {
+		var func = window._onbeforeunload;
+		if (!func._overloaded && func()) {
+			e.preventDefault();
+		}		
 	}
 
 	/**


### PR DESCRIPTION
### Intent
To add ability to **Senna.JS** to assess wether the ```window.onbeforeunload``` function is overloaded by the client code. If so and ```window.onbeforeunload``` listener returns a truthy value terminate the SPA-like navigation prematurely accordingly.

### Solution
* Added custom event ```beforeUnload``` to the App 
* When the app is being instantiated a listener is attached to the ```beforeUnload```
* This listener processes the native ```window .onbeforeunload``` to see whether it is overloaded
* When any type of SPA-navigation event occurs the App emits the ```beforeUnload``` event
* The registered handler executes the initial ```window.beforeunload``` function and determines whether the navigation should be terminated prematurely.

### Demo
![screencast-issue-212](https://user-images.githubusercontent.com/6104164/28457398-44597364-6e06-11e7-9091-e91b053e69f2.gif)

### BDD
GIVEN the client code adds a custom listener to the ```window.onbeforeunload```
AND the listener returns a truthy value
WHEN the page loads 
AND the user attempts to navigate off site by clicking on a link 
THEN the browser display a confirmation popup asking the user if the navigation should be discontinued  

GIVEN the client code adds a custom listener to the ```window.onbeforeunload```
AND the listener returns a truthy value
WHEN the page loads 
AND the user attempts to navigate off site by using the BACK button of the current browser 
THEN the browser display a confirmation popup asking the user if the navigation should be discontinued  

GIVEN the client code adds a custom listener to the ```window.onbeforeunload```
AND the listener returns a truthy value
WHEN the page loads 
AND the user attempts to refresh the page
THEN the browser display a confirmation popup asking the user if the navigation should be discontinued  

### Tested
* Chrome 59.0.1
* Safari 10.1.1
* Firefox 54.0.1