### PR TITLE
Now onScroll uses debounce on saveHistory

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -688,8 +688,8 @@ class App extends EventEmitter {
 	 * by client code. If so, it replaces with a function that halts the normal
 	 * event flow in relation with the client onbeforeunload function.
 	 * This can be in most part used to prematurely terminate navigation to other pages
-	 * according to the given constrait(s). 
-	 * @protected 
+	 * according to the given constrait(s).
+	 * @protected
 	 */
 	maybeOverloadBeforeUnload_() {
 		if ('function' === typeof window.onbeforeunload) {
@@ -702,7 +702,7 @@ class App extends EventEmitter {
 				}
 			};
 
-			// mark the updated handler due unwanted recursion 
+			// mark the updated handler due unwanted recursion
 			window.onbeforeunload._overloaded = true;
 		}
 	}
@@ -945,7 +945,7 @@ class App extends EventEmitter {
 	 */
 	onScroll_() {
 		if (this.captureScrollPositionFromScrollEvent) {
-			this.saveHistoryCurrentPageScrollPosition_(globals.window.pageYOffset, globals.window.pageXOffset);
+			debounce(this.saveHistoryCurrentPageScrollPosition_(globals.window.pageYOffset, globals.window.pageXOffset), 100);
 		}
 	}
 


### PR DESCRIPTION
When CI run my tests on #232, it catches some errors that being shown below:
![image](https://user-images.githubusercontent.com/7663513/33680620-f8dcb308-daa0-11e7-90bc-7de3f60b1b69.png)

I've noticed that `replaceState` security error is caused by spamming scroll event when updating history state. Using debounce we can reduce the occurrence of `replaceState` event and solve this Security Error. 