### PR TITLE
Only adds submit button value to request body if we can make sure it's not already there

### DIFF
--- a/src/screen/RequestScreen.js
+++ b/src/screen/RequestScreen.js
@@ -246,7 +246,13 @@ class RequestScreen extends Screen {
 	 */
 	maybeAppendSubmitButtonValue_(body) {
 		const button = globals.capturedFormButtonElement;
-		if (button && button.name) {
+
+		// Only adds submit button value if we can make sure it's not already there
+		if (typeof body.has !== 'function') {
+			return;
+		}
+
+		if (button && button.name && !body.has(button.name)) {
 			body.append(button.name, button.value);
 		}
 	}

--- a/test/screen/RequestScreen.js
+++ b/test/screen/RequestScreen.js
@@ -222,6 +222,9 @@ describe('RequestScreen', function() {
 	});
 
 	it('should add submit input button value into request FormData', (done) => {
+		if (typeof FormData.prototype.has !== 'function') {
+			done();
+		}
 		globals.capturedFormElement = globals.document.createElement('form');
 		const submitButton = globals.document.createElement('button');
 		submitButton.name = 'submitButton';


### PR DESCRIPTION
Hey @jbalsas, this is a proposal to work around the issue described by https://issues.liferay.com/browse/LPS-77680

Unfortunately, Safari didn't implement the full spec for FormData yet. So it doesn't provide the FormData.has. 

I've tried first to use https://github.com/jimmywarting/FormData but couldn't make it work. Besides, that would add a dependency and I've looked at the implementation and it patches the native fetch and XHR functions. 

This still leaves uncovered browsers who don't implement FormData.has and don't already include the submit button value by default.

Let me know what you think,

Thanks,