### PR TITLE
Updating iphone supported version for saucelabs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ var options = {
 			base: 'SauceLabs',
 			browserName: 'iphone',
 			platform: 'OS X 10.10',
-			version: '9.2'
+			version: '9.3'
 		},
 		sl_ios_10: {
 			appiumVersion: '1.6.4',


### PR DESCRIPTION
https://wiki.saucelabs.com/display/DOCS/2018/02/09/End-of-Life+for+iOS+versions+9.2+and+below+on+Simulators
tl;dr
#### End-of-Life for iOS versions 9.2 and below on Simulators
They removed support to iOS versions 9.2 and below due low marketshare and adoption rate is less than 1%.