### PR TITLE
WIP | DO NOT MERGE: Avoid execution of CancellablePromise when doNavigate is started

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -842,10 +842,11 @@ class App extends EventEmitter {
 	 */
 	onBeforeNavigateDefault_(event) {
 		if (this.pendingNavigate) {
-			if (this.pendingNavigate.path === event.path) {
-				console.log('Waiting...');
-				return;
-			}
+			// Here, we have a critic point to navigation. When avoiding 
+			// execution of beforeUnload and startNavigate event,
+			// we avoid CancellationPromise when senna lifecycle is executed.
+			// https://github.com/antonio-ortega/liferay-portal/pull/49
+			return;
 		}
 
 		this.emit('beforeUnload', event);
@@ -1114,9 +1115,11 @@ class App extends EventEmitter {
 	removeScreen(path) {
 		var screen = this.screens[path];
 		if (screen) {
+			console.log('before screen: ', screen);
 			Object.keys(this.surfaces).forEach((surfaceId) => this.surfaces[surfaceId].remove(screen.getId()));
+			console.log('after cleaning: ', screen);
 			screen.dispose();
-			delete this.screens[path];
+			this.screens[path] = null;
 		}
 	}
 


### PR DESCRIPTION
When disabling it, `pendingNavigate` process immediately cancel beforeUnload and startNavigate event, avoiding Cancellation Promise when navigation is fired.

Before, this function checked if the path of the `pendingNavigation` is the same as the received event parameter, `avoidbeforeUnload` or `startNavigate` execution. This behavior causes some issues(https://github.com/antonio-ortega/liferay-portal/pull/49) because Senna.js isn't already prepared yet for a more intelligent way of Cancellation, like running Cancellation before evaluating scripts.