### PR TITLE
Add rule not to remove the screen being used in a pending navigation

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -347,7 +347,7 @@ class App extends EventEmitter {
 		Object.keys(this.screens).forEach((path) => {
 			if (path === this.activePath) {
 				this.activeScreen.clearCache();
-			} else {
+			} else if (!(this.isNavigationPending && this.pendingNavigate.path === path)) {
 				this.removeScreen(path);
 			}
 		});


### PR DESCRIPTION
hey guys, this solves the problem when the `clearScreensCache` method is called when there is a pending navigation that is reusing a screen.