### PR TITLE
Remove the console.log when publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -703,6 +703,12 @@
         "regenerator-transform": "0.9.11"
       }
     },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
+      "dev": true
+    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "gulp build build:amd",
     "compile": "babel --presets metal --plugins transform-remove-console -d lib/ src/",
-    "prepublish": "npm run build && npm run compile"
+    "prepublish": "gulp && npm run compile"
   },
   "keywords": [
     "spa",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "gulp build build:amd",
-    "compile": "babel --presets metal -d lib/ src/",
+    "compile": "babel --presets metal --plugins transform-remove-console -d lib/ src/",
     "prepublish": "npm run build && npm run compile"
   },
   "keywords": [
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-preset-metal": "^4.0.0",
     "gulp": "^3.8.11",
     "gulp-connect": "^5.0.0",


### PR DESCRIPTION
Hey guys, the console is being properly removed for `build` when we run `gulp` only (this will run the `gulp default`), but it seems that we are not doing the releases correctly it is possible to see the logs in the files published in npm, I modified it the `prepublish` task to run only `gulp default` this may guarantee that we will release without the `build` logs.

I added a plugin for the `compile` task so that can remove the console in` lib`, so anyone who does not consume from `build` will also not see the logs.