### PR TITLE
Fixes #285 - Remove href comparison from favicon element to force browser to change favicon

### DIFF
--- a/src/screen/HtmlScreen.js
+++ b/src/screen/HtmlScreen.js
@@ -163,7 +163,7 @@ class HtmlScreen extends RequestScreen {
 
 		return new CancellablePromise((resolve) => {
 			utils.removeElementsFromDocument(resourcesInDocument);
-			this.runFaviconInElement_(resourcesInVirtual, resourcesInDocument).then(() => resolve());
+			this.runFaviconInElement_(resourcesInVirtual).then(() => resolve());
 		});
 	}
 
@@ -302,16 +302,13 @@ class HtmlScreen extends RequestScreen {
 	/**
 	 * Adds the favicon elements to the document.
 	 * @param {!Array<Element>} elements
-	 * @param {!Array<Element>} resourcesInDocument
 	 * @private
 	 * @return {CancellablePromise}
 	 */
-	runFaviconInElement_(elements, resourcesInDocument) {
+	runFaviconInElement_(elements) {
 		return new CancellablePromise((resolve) => {
 			elements.forEach((element) => document.head.appendChild(
-				utils.isEqualHref(resourcesInDocument, element) 
-					? element 
-					: utils.setElementWithRandomHref(element)
+				utils.setElementWithRandomHref(element)
 			));
 			resolve();
 		});

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -102,27 +102,6 @@ class utils {
 	}
 
 	/**
-	 * Compare the href of the node with those of the elements.
-	 * @param {!Array<Element>} elements 
-	 * @param {!Element} node 
-	 */
-	static isEqualHref(elements, node) {
-		for (let index = 0; index < elements.length; index++) {
-			let element = elements[index];
-			let oldHref = new Uri(element.href);
-			let newHref = new Uri(node.href);
-			if (
-				oldHref.removeParameter('q').toString() === 
-				newHref.removeParameter('q').toString()
-			) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Returns true if HTML5 History api is supported.
 	 * @return {boolean}
 	 * @static

--- a/test/screen/HtmlScreen.js
+++ b/test/screen/HtmlScreen.js
@@ -164,6 +164,7 @@ describe('HtmlScreen', function() {
 			var element = document.querySelector('link[rel="Shortcut Icon"]');
 			var uri = new Uri(element.href);
 			assert.strictEqual('/for/favicon.ico', uri.getPathname());
+			assert.ok(uri.hasParameter('q'));
 			exitDocumentElement('surfaceId');
 			done();
 		});
@@ -198,19 +199,6 @@ describe('HtmlScreen', function() {
 			var uri = new Uri(element.href);
 			assert.strictEqual('/for/favicon.ico', uri.getPathname());
 			assert.ok(uri.hasParameter('q'));
-			exitDocumentElement('surfaceId');
-			done();
-		});
-	});
-
-	it('should not force favicon change when href is equal', (done) => {
-		enterDocumentSurfaceElement('surfaceId', '<link rel="Shortcut Icon" href="http://localhost/foo/favicon.ico" />');
-		var surface = new Surface('surfaceId');
-		var screen = new HtmlScreen();
-		screen.allocateVirtualDocumentForContent('<link rel="Shortcut Icon" href="http://localhost/foo/favicon.ico" />');
-		screen.evaluateFavicon_().then(() => {
-			var element = document.querySelector('link[rel="Shortcut Icon"]');
-			assert.strictEqual('http://localhost/foo/favicon.ico', element.href);
 			exitDocumentElement('surfaceId');
 			done();
 		});


### PR DESCRIPTION
It seems that #285 is still being reproduced, so I'm removing the href comparison so I always add the random query in the href of the element.