### PR TITLE
Strip out the port when checking if the link is from the same origin …

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -635,7 +635,10 @@ class App extends EventEmitter {
 	 * @protected
 	 */
 	isLinkSameOrigin_(host) {
-		return host === globals.window.location.host;
+		const hostUri = new Uri(host);
+		const locationHostUri = new Uri(globals.window.location.host);
+
+		return hostUri.url.port === locationHostUri.url.port && hostUri.url.hostname == locationHostUri.url.hostname;
 	}
 
 	/**


### PR DESCRIPTION
…if it is the default port since the default port being added to the URI differs between browsers

Sent for https://github.com/liferay/senna.js/issues/290

Based on https://issues.liferay.com/browse/LPS-87416

Please note this is high priority as it's a blocker for a large US client's project go-live.