### PR TITLE
Fixes #295 do not append query to IE link

### DIFF
--- a/src/screen/HtmlScreen.js
+++ b/src/screen/HtmlScreen.js
@@ -307,7 +307,7 @@ class HtmlScreen extends RequestScreen {
 	runFaviconInElement_(elements) {
 		return new CancellablePromise((resolve) => {
 			elements.forEach((element) => document.head.appendChild(
-				utils.setElementWithRandomHref(element)
+        UA.isIe ? element : utils.setElementWithRandomHref(element)
 			));
 			resolve();
 		});


### PR DESCRIPTION
Fixes #295 

This fix will prevent any query to be appended to IE links. 
This is required behavior for https://issues.liferay.com/browse/LPS-88702.

If the fix is committed and is in the new release, the new version of senna will be added in this PR: https://github.com/matuzalemsteles/liferay-portal/pull/6#issuecomment-458219117.

Please let me know if there are any questions of comments about this.