### PR TITLE
Assume form element content-type on SPA post

### DIFF
--- a/src/screen/RequestScreen.js
+++ b/src/screen/RequestScreen.js
@@ -217,6 +217,7 @@ class RequestScreen extends Screen {
 		if (globals.capturedFormElement) {
 			this.addSafariXHRPolyfill();
 			body = this.getFormData(globals.capturedFormElement, globals.capturedFormButtonElement);
+			headers.add('Content-type', globals.capturedFormElement.enctype);
 			httpMethod = RequestScreen.POST;
 			if (UA.isIeOrEdge) {
 				headers.add('If-None-Match', '"0"');


### PR DESCRIPTION
Some left overs from https://github.com/liferay/senna.js/pull/307

Assume the original form element content-type on the ajax post.