### PR TITLE
Emit endNavigate event in a more reliable way.

### DIFF
--- a/src/screen/Screen.js
+++ b/src/screen/Screen.js
@@ -115,12 +115,15 @@ class Screen extends Cacheable {
 	 *     pause the navigation until it is resolved.
 	 */
 	evaluateScripts(surfaces) {
+	  let allScriptPromises = [];
 		Object.keys(surfaces).forEach(sId => {
 			if (surfaces[sId].activeChild) {
-				globalEval.runScriptsInElement(surfaces[sId].activeChild);
+        allScriptPromises.push(new Promise((resolve) => {
+          globalEval.runScriptsInElement(surfaces[sId].activeChild, () => resolve());
+        }));
 			}
 		});
-		return Promise.resolve();
+		return Promise.all(allScriptPromises);
 	}
 
 	/**


### PR DESCRIPTION
The emission of the event endNavigate is not consistent, because it can happen before all the scripts are parsed, making it hard to rely on. 

This way the event it's only emitted after all the javascript scripts are parsed.


