### PR TITLE
Fix the propagation of the error to the endNavigatePayload

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,8 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = space
-indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1100,8 +1100,8 @@ class App extends EventEmitter {
 				finalize(endNavigatePayload);
 			})
 			.catch((reason) => {
-        endNavigatePayload.error = reason;
-        finalize(endNavigatePayload);
+				endNavigatePayload.error = reason;
+				finalize(endNavigatePayload);
 				throw reason;
 			});
 

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1100,8 +1100,8 @@ class App extends EventEmitter {
 				finalize(endNavigatePayload);
 			})
 			.catch((reason) => {
-				finalize(endNavigatePayload);
-				endNavigatePayload.error = reason;
+        endNavigatePayload.error = reason;
+        finalize(endNavigatePayload);
 				throw reason;
 			});
 


### PR DESCRIPTION
Fix propagation of the error to the endNavigatePayload.

this.emit() runs synchronous. If we set the error after the finalize() execution, the error will never reach the 'endNavigation' cycle event 