### PR TITLE
LPS-117287 Multiple clicks on links mess up SPA navigation (WIP)

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -424,10 +424,6 @@ class App extends EventEmitter {
 			.then(() => this.maybePreventActivate_(nextScreen))
 			.then(() => nextScreen.load(path))
 			.then(() => {
-				// At this point we cannot stop navigation and all received
-				// navigate candidates will be queued at scheduledNavigationQueue.
-				this.navigationStrategy = NavigationStrategy.SCHEDULE_LAST;
-
 				if (this.activeScreen) {
 					this.activeScreen.deactivate();
 				}


### PR DESCRIPTION
This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/233. 

@diegonvs @jbalsas @brunobasto @wincent 

I am making this PR on 2.x branch:
1. `frontend-js-spa-web` is listing `"senna": "2.7.9"` as dependency
1. The solution in this PR does not work on Senna master. See details below.

The root cause of the issue is the fact that we schedule navigations. Timeline:
1. Navigation 1 starts
1. While navigation 1 is running, we start navigation 2
1. We wait for navigation 1 to to complete before immediately running navigation 2.

On the completion of navigation 1, we start loading page resources, such as editors initialization. This clashes with navigation 2, breaking on random moments, with different errors.

I don't know if it is possible to somehow ensure navigation 2 does not break resources loading. Waiting for page to be loaded seems like a bad idea, that could take a while, resulting in laggy experience. There are concepts of `Screen` activation and deactivation, but I don't think that was their intended purpose.

In this PR, we are taking the alternative solution, to **completely remove scheduling**. This fixes the issue, as navigation 2 is stopped on [this line of code](https://github.com/liferay/senna.js/blob/2.x/src/app/App.js#L910), and never re-scheduled. `this.pendingNavigate.path === event.path` is true for doubleclick. You can see the `Waiting...` line in log:

![after1](https://user-images.githubusercontent.com/5435511/90261449-3fa75380-de4d-11ea-9532-0c9bba60ff30.gif)

We added the scheduling to fix https://github.com/liferay/senna.js/issues/262 . However, when I tried to reproduce that issue, it was handled nicely, by cancellation of navigation 1. This can be seen in `Navigation error for [screen_9] (Error: Cancel pending navigation` log:

![after2](https://user-images.githubusercontent.com/5435511/90261648-8f861a80-de4d-11ea-9dc5-57423d10ba6f.gif)

Am I missing something to reproduce that ticket?

Another problem is that cancellation [exists on 2.x branch](https://github.com/liferay/senna.js/blob/2.x/src/app/App.js#L1286), but [does not exist](https://github.com/liferay/senna.js/blob/master/src/app/App.js#L1298) on master. The solution in this PR **does not work on master**. I am unsure how to proceed, this requires deeper understanding of why this was changed (hence WIP). 

Minor notes:
- The solution in https://github.com/liferay-frontend/liferay-portal/pull/233 is completely wrong, it was an odd coincidence that it worked. But, to pat myself on the back, I wasn't that far off in creating a link delegate, implementation is [very similar in Senna](https://github.com/liferay/senna.js/blob/7a5dc7a197194e2676d9829fab1030789b1ff320/src/app/App.js#L1261), but will layers on top.
- I was not able to easily integrate this repo to local portal instance. `yarn add "path_to_local_repo"` does not work. I end up with a lot of missing dependencies in console log.
- I was not able to run tests on this repo. The issue seems to be in `gulp` + my node v14 (`primordials is not defined` error). I didn't delve too deep into how to fix it.
- Prettier does not like this repo.