### PR TITLE
fix: Avoids scheduling a navigation to the same path

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -308,9 +308,10 @@ class App extends EventEmitter {
 	/**
 	 * Returns if can navigate to path.
 	 * @param {!string} url
+	 * @param {!Event} event Dom event that initiated the navigation.
 	 * @return {boolean}
 	 */
-	canNavigate(url) {
+	canNavigate(url, event) {
 		const uri = utils.isWebUri(url);
 
 		if (!uri) {
@@ -325,6 +326,11 @@ class App extends EventEmitter {
 		}
 		if (!this.isSameBasePath_(path)) {
 			console.log('Link clicked outside app\'s base path');
+			return false;
+		}
+		if (this.isSamePendingNavigationPath_(path)) {
+			console.log('Discarding the navigation because is trying to navigate to the same path');
+			event.preventDefault();
 			return false;
 		}
 		// Prevents navigation if it's a hash change on the same url.
@@ -652,6 +658,20 @@ class App extends EventEmitter {
 	}
 
 	/**
+	 * Tests if the given path is the same of the current pendingNavigate.
+	 * @param {!string} path Link path containing the querystring part.
+	 * @return {boolean}
+	 * @protected
+	 */
+	isSamePendingNavigationPath_(path) {
+		if (this.isNavigationPending && utils.getUrlPath(this.pendingNavigate.path) === path) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Lock the document scroll in order to avoid the browser native back and
 	 * forward navigation to change the scroll position. In the end of
 	 * navigation lifecycle scroll is repositioned.
@@ -716,7 +736,7 @@ class App extends EventEmitter {
 	 * @param {Event} event Dom event that initiated the navigation.
 	 */
 	maybeNavigate_(href, event) {
-		if (!this.canNavigate(href)) {
+		if (!this.canNavigate(href, event)) {
 			return;
 		}
 

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -308,10 +308,9 @@ class App extends EventEmitter {
 	/**
 	 * Returns if can navigate to path.
 	 * @param {!string} url
-	 * @param {!Event} event Dom event that initiated the navigation.
 	 * @return {boolean}
 	 */
-	canNavigate(url, event) {
+	canNavigate(url) {
 		const uri = utils.isWebUri(url);
 
 		if (!uri) {
@@ -326,11 +325,6 @@ class App extends EventEmitter {
 		}
 		if (!this.isSameBasePath_(path)) {
 			console.log('Link clicked outside app\'s base path');
-			return false;
-		}
-		if (this.isSamePendingNavigationPath_(path)) {
-			console.log('Discarding the navigation because is trying to navigate to the same path');
-			event.preventDefault();
 			return false;
 		}
 		// Prevents navigation if it's a hash change on the same url.
@@ -732,7 +726,15 @@ class App extends EventEmitter {
 	 * @param {Event} event Dom event that initiated the navigation.
 	 */
 	maybeNavigate_(href, event) {
-		if (!this.canNavigate(href, event)) {
+		const path = utils.getUrlPath(href);
+
+		if (this.isSamePendingNavigationPath_(path)) {
+			console.log('Discarding the navigation because is trying to navigate to the same path');
+			event.preventDefault();
+			return;
+		}
+
+		if (!this.canNavigate(href)) {
 			return;
 		}
 
@@ -745,7 +747,7 @@ class App extends EventEmitter {
 
 		var navigateFailed = false;
 		try {
-			this.navigate(utils.getUrlPath(href), false, event);
+			this.navigate(path, false, event);
 		} catch (err) {
 			// Do not prevent link navigation in case some synchronous error occurs
 			navigateFailed = true;

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -664,11 +664,7 @@ class App extends EventEmitter {
 	 * @protected
 	 */
 	isSamePendingNavigationPath_(path) {
-		if (this.isNavigationPending && utils.getUrlPath(this.pendingNavigate.path) === path) {
-			return true;
-		}
-
-		return false;
+		return this.isNavigationPending && utils.getUrlPath(this.pendingNavigate.path) === path;
 	}
 
 	/**

--- a/src/screen/RequestScreen.js
+++ b/src/screen/RequestScreen.js
@@ -189,18 +189,18 @@ class RequestScreen extends Screen {
 		return statusCode >= 200 && statusCode <= 399;
 	}
 
-  /**
-   * Returns the form data
-   * This method can be extended in order to have a custom implementation of the form params
-   * @param {!Element} formElement
-   * @param {!Element} submittedButtonElement
-   * @return {!FormData}
-   */
+	/**
+	 * Returns the form data
+	 * This method can be extended in order to have a custom implementation of the form params
+	 * @param {!Element} formElement
+	 * @param {!Element} submittedButtonElement
+	 * @return {!FormData}
+	 */
 	getFormData(formElement, submittedButtonElement) {
-    let formData = new FormData(formElement);
-    this.maybeAppendSubmitButtonValue_(formData, submittedButtonElement);
-    return formData;
-  }
+		let formData = new FormData(formElement);
+		this.maybeAppendSubmitButtonValue_(formData, submittedButtonElement);
+		return formData;
+	}
 
 	/**
 	 * @inheritDoc
@@ -262,7 +262,7 @@ class RequestScreen extends Screen {
 	 */
 	maybeAppendSubmitButtonValue_(formData, submittedButtonElement) {
 		if (submittedButtonElement && submittedButtonElement.name) {
-      formData.append(submittedButtonElement.name, submittedButtonElement.value);
+			formData.append(submittedButtonElement.name, submittedButtonElement.value);
 		}
 	}
 


### PR DESCRIPTION
It prevents a navigation to be scheduled from the same path

#### How to run Senna(updated Aug 2020 😂 )

1. Set your node version to `v6.14.3`
2. When installing, avoid updating package-lock.json just running `npm ci` instead of `npm i`
3. Before building, we need to fix an issue on gulp-metal -> node-sass dep
3.1 Go to `node_modules/gulp-metal/node-sass`
3.2 Run `node scripts/install.js`
3.3 Go back to gulp-metal folder, and run `npm rebuild node-sass`
3.4 Go back to senna's folder
4. Make sure you have a globally installed gulp@3
5. Run `gulp && gulp server`

It will work

### Test Case

When linking the package on DXP, running the steps provided on https://github.com/liferay/senna.js/pull/337, when double clicking on a "navigation starter" element, We aren't no more pushing a duplicate path to scheduledNavigations queue.

